### PR TITLE
Fix flaky test failure in IgniteToStringBuilderSelfTest#testToString

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/tostring/IgniteToStringBuilderSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/tostring/IgniteToStringBuilderSelfTest.java
@@ -58,7 +58,21 @@ public class IgniteToStringBuilderSelfTest extends IgniteAbstractTest {
     public void testToString() {
         TestClass1 obj = new TestClass1();
 
-        assertEquals(obj.toStringManual(), obj.toStringAutomatic());
+        assertEquals(sortFieldsInToString(obj.toStringManual()), sortFieldsInToString(obj.toStringAutomatic()));
+    }
+
+    private String sortFieldsInToString(String input){
+        int startIndex = input.indexOf('[') + 1;
+        int endIndex = input.indexOf(']');
+
+        String toStringFields = input.substring(startIndex, endIndex);
+        String[] elements = toStringFields.split(", ");
+        Arrays.sort(elements);
+
+        String sortedContent = String.join(", ", elements);
+        String sortedToString = input.replace(toStringFields, sortedContent);
+
+        return sortedToString;
     }
 
     @Test

--- a/modules/core/src/test/java/org/apache/ignite/internal/tostring/IgniteToStringBuilderSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/tostring/IgniteToStringBuilderSelfTest.java
@@ -62,17 +62,12 @@ public class IgniteToStringBuilderSelfTest extends IgniteAbstractTest {
     }
 
     private String sortFieldsInToString(String input){
-        int startIndex = input.indexOf('[') + 1;
-        int endIndex = input.indexOf(']');
+        String toStringFields = input.substring(input.indexOf('[') + 1, input.indexOf(']'));
 
-        String toStringFields = input.substring(startIndex, endIndex);
         String[] elements = toStringFields.split(", ");
         Arrays.sort(elements);
 
-        String sortedContent = String.join(", ", elements);
-        String sortedToString = input.replace(toStringFields, sortedContent);
-
-        return sortedToString;
+        return input.replace(toStringFields, String.join(", ", elements));
     }
 
     @Test

--- a/modules/core/src/test/java/org/apache/ignite/internal/tostring/IgniteToStringBuilderSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/tostring/IgniteToStringBuilderSelfTest.java
@@ -63,10 +63,8 @@ public class IgniteToStringBuilderSelfTest extends IgniteAbstractTest {
 
     private String sortFieldsInToString(String input){
         String toStringFields = input.substring(input.indexOf('[') + 1, input.indexOf(']'));
-
         String[] elements = toStringFields.split(", ");
         Arrays.sort(elements);
-
         return input.replace(toStringFields, String.join(", ", elements));
     }
 


### PR DESCRIPTION
### What is the purpose of this PR

- This PR fixes the error resulting from the flaky test in `org.apache.ignite.internal.tostring.IgniteToStringBuilderSelfTest.testToString`
- The mentioned tests may fail or pass without changes made to the source code when it is run in different JVMs due to `java.lang.Class.getDeclaredFields()`'s non-deterministic output order.

### Why the tests fails

- `toString(Class<T> cls, T obj)` of `IgniteToStringBuilder.java` returns the string representation of a class with its fields. In its implementation `getClassDescriptor()` is called with the given class. `getClassDescriptor()` uses `getDeclaredFields()` of `java.lang.Class` to get all the fields of the class. But according to [Java documentation](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--), `getDeclaredFields`, does not return its elements in any particular order. 
- In the test assertion, `toStringManual()` constructs the string in a fixed order. On the other hand, the order of elements of the returned string of `toStringAutomatic()` is not fixed. 

### How to reproduce the test failure

Run the test with 'NonDex' maven plugin.  The commit id where the flaky test was found is: `a1aa7fd4e2398c72827777ec5417d67915ff4da3`. And the test is still flaky in the main branch. To reproduce the flaky test failures, clone the repository, move to the created folder and then run the following commands

- `git checkout a1aa7fd4e2398c72827777ec5417d67915ff4da3`
- `mvn -pl modules/core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.ignite.internal.tostring.IgniteToStringBuilderSelfTest#testToString`
- `./gradlew :ignite-core/nondexTest --test "org.apache.ignite.internal.tostring.IgniteToStringBuilderSelfTest.testToString"`

### Expected results
All tests should pass when run with NonDex.

### Actual results
One of the assertion failures was:
`[ERROR] Failures: 
[ERROR]   IgniteToStringBuilderSelfTest.testToString:61 expected: <TestClass1 [id=1234567890, uuidVar=93d2c6cb-ae17-457e-bd87-be6b087b3789, intVar=0, boolVar=false, byteVar=0, name=qwertyuiopasdfghjklzxcvbnm, finalInt=2, strMap=null, strListIncl=null]> but was: <TestClass1 [id=1234567890, uuidVar=93d2c6cb-ae17-457e-bd87-be6b087b3789, strMap=null, finalInt=2, name=qwertyuiopasdfghjklzxcvbnm, boolVar=false, strListIncl=null, byteVar=0, intVar=0]>`

### Description of fix
Extracted the fields with values from the returned string of both `toStringManual()` and `toStringAutomatic()`, sorted them, and finally created a new string with the sorted items.